### PR TITLE
Add SageMaker Geospatial verison 1.x images

### DIFF
--- a/src/sagemaker/image_uri_config/sagemaker-geospatial.json
+++ b/src/sagemaker/image_uri_config/sagemaker-geospatial.json
@@ -1,0 +1,13 @@
+{
+    "processing": {
+      "versions": {
+        "1.x": {
+          "registries": {
+            "us-west-2": "081189585635"
+          },
+          "repository": "sagemaker-geospatial-v1-0",
+          "tag_prefix": "latest"
+        } 
+      }
+    }
+  }

--- a/tests/unit/sagemaker/image_uris/expected_uris.py
+++ b/tests/unit/sagemaker/image_uris/expected_uris.py
@@ -54,6 +54,11 @@ def algo_uri(algo, account, region, version=1):
     return IMAGE_URI_FORMAT.format(account, region, domain, algo, version)
 
 
+def algo_uri_with_tag(algo, account, region,tag):
+    domain = ALTERNATE_DOMAINS.get(region, DOMAIN)
+    return IMAGE_URI_FORMAT.format(account, region, domain, algo, tag)
+
+
 def monitor_uri(account, region=REGION):
     domain = ALTERNATE_DOMAINS.get(region, DOMAIN)
     return MONITOR_URI_FORMAT.format(account, region, domain)

--- a/tests/unit/sagemaker/image_uris/test_sagemaker_geospatial.py
+++ b/tests/unit/sagemaker/image_uris/test_sagemaker_geospatial.py
@@ -1,0 +1,55 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import absolute_import
+
+import pytest
+from sagemaker import image_uris
+from tests.unit.sagemaker.image_uris import expected_uris
+
+
+def _test_ecr_uri(account, region, version, tag):
+    actual_uri = image_uris.retrieve("sagemaker-geospatial", region=region, version=version)
+    expected_uri = expected_uris.algo_uri_with_tag(
+        "sagemaker-geospatial-v1-0",
+        account,
+        region,
+        tag=tag,
+    )
+    return expected_uri == actual_uri
+
+
+@pytest.mark.parametrize("load_config", ["sagemaker-geospatial.json"], indirect=True)
+@pytest.mark.parametrize("extract_versions_for_image_scope", ["processing"], indirect=True)
+def test_sagemaker_geospatial_ecr_uri(load_config, extract_versions_for_image_scope):
+    VERSIONS = extract_versions_for_image_scope
+    for version in VERSIONS:
+        SAGEMAKER_GEOSPATIAL_ACCOUNTS = load_config["processing"]["versions"][version]["registries"]
+        for region in SAGEMAKER_GEOSPATIAL_ACCOUNTS.keys():
+         
+            assert _test_ecr_uri(
+                account=SAGEMAKER_GEOSPATIAL_ACCOUNTS[region], region=region, version=version, tag ="latest"
+            )
+            
+
+@pytest.mark.parametrize("load_config", ["sagemaker-geospatial.json"], indirect=True)
+def test_sagemaker_geospatial_ecr_uri_no_version(load_config):
+    region = "us-west-2"
+    SAGEMAKER_GEOSPATIAL_ACCOUNTS = load_config["processing"]["versions"]["1.x"]["registries"]
+    actual_uri = image_uris.retrieve("sagemaker-geospatial", region=region)
+    expected_uri = expected_uris.algo_uri_with_tag(
+        "sagemaker-geospatial-v1-0",
+        SAGEMAKER_GEOSPATIAL_ACCOUNTS[region],
+        region,
+        tag ="latest"
+    )
+    assert expected_uri == actual_uri


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Adding the SageMaker Geospatial Images in us-west-2
*Testing done:*
 * Added Unit Tests
 * Ran all the unit tests using tox -e py310 -- -s -vv tests/unit 
 * Ran Single Unit tests 
   * sagemaker-python-sdk % sagemaker-python-sdk % export IGNORE_COVERAGE=- ; tox -e py310 -- -s 
     -vv tests/unit/sagemaker/image_uris/test_sagemaker_geospatial.py::test_sagemaker_geospatial_ecr_uri_no_version; 
     unset IGNORE_COVERAGE
   * sagemaker-python-sdk % sagemaker-python-sdk % export IGNORE_COVERAGE=- ; tox -e py310 -- -s
     -vv tests/unit/sagemaker/image_uris/test_sagemaker_geospatial.py::test_sagemaker_geospatial_ecr_$
     unset IGNORE_COVERAGE


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the 
[CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I certify that the changes I am introducing will be backward compatible, and I have 
discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in 
[CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [x] I have updated any necessary documentation, including 
[READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if 
appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward 
compatibility of the changes
- [x] I have checked that my tests are not configured for a specific region or account (if 
appropriate)
- [ ] I have used 
[`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
